### PR TITLE
Silencing error by falling back to empty array.

### DIFF
--- a/lib/tld-hints.js
+++ b/lib/tld-hints.js
@@ -24,6 +24,12 @@ function getTldsHelper() {
     }
   }
 
+  // Somehow tlds can be an object, which cannot call filter against.
+  // Just cast it to an empty Array if it doesnt appear to be one.
+  if (!domains.tlds.length) {
+    domains.tlds = [];
+  }
+
   domains.tlds = domains.tlds.filter(function (tld) {
     return tld.enabled
       // think of the children!
@@ -59,6 +65,13 @@ function getTldsAsync() {
     var tlds = JSON.parse(req.body);
     var path = require('path');
     var fs = require('fs');
+
+    // Do a sanity check, to make sure the response is an Array.
+    if (req.body[0] !== '[') {
+      console.error("TLDs response is not an array, falling back to an empty list");
+      console.log(req.body);
+      tlds = [];
+    }
 
     domains.tlds = tlds;
     domains.updatedAt = Date.now();


### PR DESCRIPTION
Rather than failing when trying to .filter against an error object.  This just falls-back onto on empty array... However, this isn't really a fix, more just showing where the problem exists.

For a real solution, I need to find out how to get my domains.json file back into a "successful-response" state.  As things stand now it wont let me beyond the first domains:search screen, since it has nothing to "autocomplete" against.
