### PR TITLE
Not a fix, but throw a descriptive error when SLD is empty

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1703,7 +1703,8 @@ function getDomainAvailability(state) {
   var tld  = r.tld;
   var sld = r.sld;
 
-  if (!q) {
+  // Reject queries against invalid domain name (empty secondary-level)
+  if (!q || !sld) {
     return PromiseA.reject(new Error("don't submit non-domains please"));
   }
 


### PR DESCRIPTION
I plan on digging deeper, on how to gracefully continue the cli GUI with a response message instead of just failing out to the command prompt.  For now, these PRs are just to get my feet wet.  
